### PR TITLE
fix: function definition of init missing comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ historical archival.
         def base_url(), do: "https://books.toscrape.com/"
 
         @impl Crawly.Spider
-        def init() do: [start_urls: ["https://books.toscrape.com/"]]
+        def init(), do: [start_urls: ["https://books.toscrape.com/"]]
 
         @impl Crawly.Spider
         def parse_item(response) do


### PR DESCRIPTION
In the readme example, the function definition of init() on line 44 is missing the comma required for single line function definitions. 
Copy pasting the example will result in error without this comma.